### PR TITLE
Ship a more sane .gitattributes with the project

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
-# Set default behaviour, in case users don't have core.autocrlf set.
-* text=auto
+# Do not change the line endings by default
+* -text
 
 # Explicitly declare text files we want to always be normalized and converted
 # to native line endings on checkout.
@@ -8,10 +8,3 @@
 *.mo text
 *.mos text
 *.order text
-*.eps -text
-*.sln eol=crlf
-*.vcproj eol=crlf
-
-# Denote all files that are truly binary and should not be modified.
-*.png binary
-*.jpg binary


### PR DESCRIPTION
This is related to the issue contributors had earlier on with the line endings. This solution basically forbids line-ending changes on all files by default and only marks specific files as "text" which then means that the local settings of the person checking the files out will determine what happens to the line endings on her machine.
