### PR TITLE
Compilation support for Open Modelica with clang under Linux

### DIFF
--- a/Noise 0.2.0/Resources/Include/ModelicaNoise.c
+++ b/Noise 0.2.0/Resources/Include/ModelicaNoise.c
@@ -11,13 +11,22 @@ typedef long LONG;
 typedef unsigned char    u_char;
 typedef unsigned short   u_short;
 typedef unsigned int     u_int;
-typedef unsigned __int32 u_int32;
 typedef unsigned long    u_long;
-typedef unsigned __int64 u_int64;
+
+#ifdef _MSC_VER
+typedef __int32 int32_t;
+typedef unsigned __int32 uint32_t;
+typedef __int64 int64_t;
+typedef unsigned __int64 uint64_t;
+#include <windows.h>
+#else
+#include <stdint.h>
+#endif
+
+
 #include <stdio.h>
 #include <limits.h>
 #include  "ModelicaUtilities.h"  
-#include <windows.h> 
 #include <math.h> 
 
 
@@ -26,15 +35,15 @@ typedef unsigned __int64 u_int64;
 void NOISE_SeedReal(int local_seed, int global_seed, double real_seed, int n, int* states)
 {
   double   x0;
-  u_int32* xp;
-  u_int32  x1;
-  u_int32  x2;
+  uint32_t* xp;
+  uint32_t  x1;
+  uint32_t  x2;
   int      i;
   
   // Take the square root in order to remove sampling effects
   x0 = sqrt(real_seed);
   // Point a 32 bit integer to the double number
-  xp = (u_int32*)&x0;
+  xp = (uint32_t*)&x0;
   // Interpret the first 32 bits as an integer
   x1 = *xp;
   x2 = *xp;
@@ -44,8 +53,8 @@ void NOISE_SeedReal(int local_seed, int global_seed, double real_seed, int n, in
   x2 ^= *xp;
   
   // Use the seeds to bit-wier XOR them to the two integers
-  x1 ^= (u_int32)local_seed;
-  x2 ^= (u_int32)global_seed;
+  x1 ^= (uint32_t)local_seed;
+  x2 ^= (uint32_t)global_seed;
   
   // Fill the states vector
   for (i = 0; i < n; i++){
@@ -56,20 +65,20 @@ void NOISE_SeedReal(int local_seed, int global_seed, double real_seed, int n, in
 
 // NOISE_shuffleDouble
 // This is the basic implementation of the DIRCS random number generator
-double NOISE_shuffleDouble(double x, u_int32 seed)
+double NOISE_shuffleDouble(double x, uint32_t seed)
 {
   double   x0;
-  u_int32* xp;
-  u_int32  x1;
-  u_int32  x2;
-  u_int32  xt;
+  uint32_t* xp;
+  uint32_t  x1;
+  uint32_t  x2;
+  uint32_t  xt;
   double   vmax;
   double   y;
 
   // Take the square root in order to remove sampling effects
   x0 = sqrt(x);
   // Point a 32 bit integer to the double number
-  xp = (u_int32*)&x0;
+  xp = (uint32_t*)&x0;
   // Interpret the first 32 bits as an integer
   x1 = *xp;
   x2 = *xp;


### PR DESCRIPTION
Use stdint.h of C99 to enable support for openmodelica. The behavior in windows remains unchanged.