### PR TITLE
Convolution

### DIFF
--- a/Modelica_Noise 1.0-Alpha.1/Blocks/Examples/NoiseExamples/Interpolation.mo
+++ b/Modelica_Noise 1.0-Alpha.1/Blocks/Examples/NoiseExamples/Interpolation.mo
@@ -17,7 +17,10 @@ model Interpolation
     samplePeriod=0.1,
     sampleFactor=10,
     y_min=-1,
-    y_max=3) annotation (Placement(transformation(extent={{-60,20},{-40,40}})));
+    y_max=3,
+    redeclare package interpolation =
+        Modelica_Noise.Math.Random.Utilities.Interpolators.Linear)
+             annotation (Placement(transformation(extent={{-60,20},{-40,40}})));
   Blocks.Noise.TimeBasedNoise smoothNoise(
     useAutomaticLocalSeed=false,
     samplePeriod=0.1,

--- a/Modelica_Noise 1.0-Alpha.1/Blocks/Noise/SignalBasedNoise.mo
+++ b/Modelica_Noise 1.0-Alpha.1/Blocks/Noise/SignalBasedNoise.mo
@@ -187,10 +187,12 @@ equation
   y = if not generateNoise then y_off else
       if interpolation.continuous then
           smooth(interpolation.smoothness,
-                 interpolation.interpolate(buffer=buffer,
-                                           offset=offset - zeroDer(noEvent(integer(offset))) + nPast)) else
-                 interpolation.interpolate(buffer=buffer,
-                                           offset=offset - zeroDer(       (integer(offset))) + nPast);
+                 interpolation.interpolate(buffer=       buffer,
+                                           offset=       offset - zeroDer(noEvent(integer(offset))) + nPast,
+                                           samplePeriod= samplePeriod)) else
+                 interpolation.interpolate(buffer=       buffer,
+                                           offset=       offset - zeroDer(       (integer(offset))) + nPast,
+                                           samplePeriod= samplePeriod);
 
   // We require a few smooth functions for derivatives
 protected

--- a/Modelica_Noise 1.0-Alpha.1/Blocks/Noise/TimeBasedNoise.mo
+++ b/Modelica_Noise 1.0-Alpha.1/Blocks/Noise/TimeBasedNoise.mo
@@ -188,10 +188,12 @@ equation
   y = if not generateNoise or time < startTime then y_off else
       if interpolation.continuous then
           smooth(interpolation.smoothness,
-                 interpolation.interpolate(buffer=buffer,
-                                           offset=(time-bufferStartTime) / samplePeriod + nPast)) else
-                 interpolation.interpolate(buffer=buffer,
-                                           offset=(time-bufferStartTime) / samplePeriod + nPast);
+                 interpolation.interpolate(buffer=       buffer,
+                                           offset=       (time-bufferStartTime) / samplePeriod + nPast,
+                                           samplePeriod= samplePeriod)) else
+                 interpolation.interpolate(buffer=       buffer,
+                                           offset=       (time-bufferStartTime) / samplePeriod + nPast,
+                                           samplePeriod= samplePeriod);
 
     annotation(Dialog(tab="Advanced",group = "Initialization",enable=enableNoise),
               Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},

--- a/Modelica_Noise 1.0-Alpha.1/Math/Random/Utilities/Interfaces/PartialInterpolator/package.mo
+++ b/Modelica_Noise 1.0-Alpha.1/Math/Random/Utilities/Interfaces/PartialInterpolator/package.mo
@@ -18,6 +18,7 @@ partial package PartialInterpolator "Interfaces of an interpolator in a buffer o
     extends Modelica.Icons.Function;
     input Real buffer[:] "Buffer of random numbers";
     input Real offset "Offset from buffer start (0..size(buffer)-1";
+    input Real samplePeriod = 1 "The sample period of the noise buffer";
     output Real y "Interpolated value at position offset";
 protected
     Integer nBuffer = size(buffer,1) "Size of the buffer";

--- a/Modelica_Noise 1.0-Alpha.1/Math/Random/Utilities/Interpolators/Linear/der_interpolate.mo
+++ b/Modelica_Noise 1.0-Alpha.1/Math/Random/Utilities/Interpolators/Linear/der_interpolate.mo
@@ -3,8 +3,10 @@ function der_interpolate
   extends Modelica.Icons.Function;
   input Real buffer[:] "Buffer of random numbers";
   input Real offset "Offset from buffer start (0..size(buffer)-1";
+  input Real samplePeriod = 1 "The sample period of the noise buffer";
   input Real der_buffer[size(buffer,1)] "Derivatives of buffer values";
   input Real der_offset "Derivative of offset value";
+  input Real der_samplePeriod "Derivative of samplePeriod (unused)";
   output Real der_y "Interpolated value at position offset";
 protected
   Integer ind "Index of buffer element just before offset";

--- a/Modelica_Noise 1.0-Alpha.1/Math/Random/Utilities/Interpolators/SmoothIdealLowPass/der_interpolate.mo
+++ b/Modelica_Noise 1.0-Alpha.1/Math/Random/Utilities/Interpolators/SmoothIdealLowPass/der_interpolate.mo
@@ -3,8 +3,10 @@ function der_interpolate "Interpolates the buffer using a replaceable kernel"
   extends Modelica.Icons.Function;
   input Real buffer[:] "Buffer of random numbers";
   input Real offset "Offset from buffer start (0..size(buffer)-1";
+  input Real samplePeriod = 1 "The sample period of the noise buffer";
   input Real der_buffer[size(buffer,1)] "Derivatives of buffer values";
   input Real der_offset "Derivative of offset value";
+  input Real der_samplePeriod "Derivative of samplePeriod (unused)";
   output Real der_y "Interpolated value at position offset";
 algorithm
   // For a general kernel based interpolation:

--- a/Noise 1.0-Alpha.1/Examples/FrequencyShaping.mo
+++ b/Noise 1.0-Alpha.1/Examples/FrequencyShaping.mo
@@ -12,6 +12,35 @@ model FrequencyShaping
     annotation (Placement(transformation(extent={{-60,40},{-40,60}})));
   inner Modelica_Noise.Blocks.Noise.GlobalSeed globalSeed(useAutomaticSeed=
         false) annotation (Placement(transformation(extent={{60,60},{80,80}})));
+  Modelica_Noise.Blocks.Noise.TimeBasedNoise rawNoise(
+    useAutomaticLocalSeed=false,
+    y_min=-1,
+    y_max=3,
+    sampleFactor=10,
+    samplePeriod=filteredNoise.samplePeriod)
+    annotation (Placement(transformation(extent={{-60,0},{-40,20}})));
+  Modelica.Blocks.Continuous.FirstOrder firstOrder(
+    k=filteredNoise.interpolation.k,
+    T=filteredNoise.interpolation.T,
+    initType=Modelica.Blocks.Types.Init.InitialState)
+    annotation (Placement(transformation(extent={{-20,0},{0,20}})));
+  Modelica.Blocks.Continuous.Der derConvolution
+    annotation (Placement(transformation(extent={{20,40},{40,60}})));
+  Modelica.Blocks.Continuous.Der derFilter
+    annotation (Placement(transformation(extent={{20,0},{40,20}})));
+equation
+  connect(rawNoise.y, firstOrder.u) annotation (Line(
+      points={{-39,10},{-22,10}},
+      color={0,0,127},
+      smooth=Smooth.None));
+  connect(firstOrder.y, derFilter.u) annotation (Line(
+      points={{1,10},{18,10}},
+      color={0,0,127},
+      smooth=Smooth.None));
+  connect(derConvolution.u, filteredNoise.y) annotation (Line(
+      points={{18,50},{-39,50}},
+      color={0,0,127},
+      smooth=Smooth.None));
   annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
             -100},{100,100}}), graphics));
 end FrequencyShaping;

--- a/Noise 1.0-Alpha.1/Examples/FrequencyShaping.mo
+++ b/Noise 1.0-Alpha.1/Examples/FrequencyShaping.mo
@@ -1,0 +1,17 @@
+within Noise.Examples;
+model FrequencyShaping
+  "Demonstrates shaping of the frequency content with a convolution filter"
+  extends Modelica.Icons.Example;
+  Modelica_Noise.Blocks.Noise.TimeBasedNoise filteredNoise(
+    useAutomaticLocalSeed=false,
+    samplePeriod=0.1,
+    y_min=-1,
+    y_max=3,
+    sampleFactor=10,
+    redeclare package interpolation = Noise.Interpolators.FirstOrder)
+    annotation (Placement(transformation(extent={{-60,40},{-40,60}})));
+  inner Modelica_Noise.Blocks.Noise.GlobalSeed globalSeed(useAutomaticSeed=
+        false) annotation (Placement(transformation(extent={{60,60},{80,80}})));
+  annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
+            -100},{100,100}}), graphics));
+end FrequencyShaping;

--- a/Noise 1.0-Alpha.1/Examples/package.order
+++ b/Noise 1.0-Alpha.1/Examples/package.order
@@ -1,3 +1,4 @@
+FrequencyShaping
 Interpolation
 Correlations
 Derivatives

--- a/Noise 1.0-Alpha.1/Interpolators/FirstOrder/package.mo
+++ b/Noise 1.0-Alpha.1/Interpolators/FirstOrder/package.mo
@@ -27,13 +27,8 @@ protected
     //
     // Step response:
     // h = b/a*(1-e^(-at)) for t >= 0
-    //
-    // Step response after a zero-order hold:
-    // h = b/a*(1-e^(-at))           for t >= 0 and t < 1
-    //   = b/a*(1-e^(-a ))*(-a(t-1)) for t >= 1
-    h := if t < 0 then 0 else
-         if t < 0.1 then b/a * (1-exp(-a*t)) else
-                       b/a * (1-exp(-a*0.1))   * exp(-a* (t-0.1));
+    h := if t < 0 then 0 else b/a * (1-exp(-a*t));
+
     annotation(Inline=true);
   end kernel;
 

--- a/Noise 1.0-Alpha.1/Interpolators/FirstOrder/package.mo
+++ b/Noise 1.0-Alpha.1/Interpolators/FirstOrder/package.mo
@@ -6,7 +6,7 @@ package FirstOrder "A linear first order filter (k / (Ts + 1))"
                                                              varianceFactor=0.900004539919624);
 
   constant Real k=1 "Gain";
-  constant Modelica.SIunits.Period T=0.1 "Time Constant";
+  constant Modelica.SIunits.Period T=0.01 "Time Constant";
 
 
   redeclare function extends kernel
@@ -32,8 +32,8 @@ protected
     // h = b/a*(1-e^(-at))           for t >= 0 and t < 1
     //   = b/a*(1-e^(-a ))*(-a(t-1)) for t >= 1
     h := if t < 0 then 0 else
-         if t < 1 then b/a * (1-exp(-a*t)) else
-                       b/a * (1-exp(-a))   * exp(-a* (t-1.0));
+         if t < 0.1 then b/a * (1-exp(-a*t)) else
+                       b/a * (1-exp(-a*0.1))   * exp(-a* (t-0.1));
     annotation(Inline=true);
   end kernel;
 

--- a/Noise 1.0-Alpha.1/Interpolators/Utilities/Interfaces/PartialInterpolatorWithKernel/der_interpolate.mo
+++ b/Noise 1.0-Alpha.1/Interpolators/Utilities/Interfaces/PartialInterpolatorWithKernel/der_interpolate.mo
@@ -3,24 +3,28 @@ function der_interpolate "Interpolates the buffer using a replaceable kernel"
   extends Modelica.Icons.Function;
   input Real buffer[:] "Buffer of random numbers";
   input Real offset "Offset from buffer start (0..size(buffer)-1";
+  input Real samplePeriod = 1 "The sample period of the noise buffer";
   input Real der_buffer[size(buffer,1)] "Derivatives of buffer values";
   input Real der_offset "Derivative of offset value";
+  input Real der_samplePeriod = 1 "The sample period of the noise buffer";
   output Real der_y "Interpolated value at position offset";
 algorithm
   // For a general kernel based interpolation:
-  // y   = sum( (K(-o)   * b[i])  )
-  // y'  = sum( (K(-o)   * b[i])' )
-  //     = sum(  K(-o)'  * b[i]        + K(o) * b[i]' )
-  //     = sum( -dK/do*o'* b[i]        + K(o) * b[i]' )
-  //     = sum( -dK/do   * b[i] ) * o'
-  //     + sum(                          K(o) * b[i]' )
+  // y   = sum( (DK(-o*s)   * b[i])  )
+  // y'  = sum( (DK(-o*s)   * b[i])' )
+  //     = sum(  DK(-o*s)'  * b[i]          + DK(-o*s) * b[i]' )
+  //     = sum( -dDK/do*o'*s* b[i]          + DK(-o*s) * b[i]' )
+  //     = sum( -dDK/do     * b[i] ) * o'*s
+  //     + sum(                               DK(-o*s) * b[i]' )
 
   // Initialize the convolution algorithm
   der_y   := 0;
 
   // Calculate weighted sum over -nPast...nFuture random samples
   for i in -nPast:nFuture loop
-    der_y := der_y + der_kernel_offset(t=mod(offset,1)-i) *     buffer[integer(offset)+i+1] * der_offset
-                   +     kernel(       t=mod(offset,1)-i) * der_buffer[integer(offset)+i+1];
+    der_y := der_y + ( - der_kernel_offset(t=(mod(offset,1)-i-1)*samplePeriod)
+                       + der_kernel_offset(t=(mod(offset,1)-i+0)*samplePeriod))  *     buffer[integer(offset)+i+1] * der_offset*samplePeriod
+                   + ( -     kernel(       t=(mod(offset,1)-i-1)*samplePeriod)
+                       +     kernel(       t=(mod(offset,1)-i+0)*samplePeriod))  * der_buffer[integer(offset)+i+1];
   end for;
 end der_interpolate;

--- a/Noise 1.0-Alpha.1/Interpolators/Utilities/Interfaces/PartialInterpolatorWithKernel/package.mo
+++ b/Noise 1.0-Alpha.1/Interpolators/Utilities/Interfaces/PartialInterpolatorWithKernel/package.mo
@@ -5,8 +5,6 @@ partial package PartialInterpolatorWithKernel "Generic interpolator interface pr
 
   redeclare replaceable function extends interpolate
   "Interpolates the buffer using a replaceable kernel"
-    input Modelica.SIunits.Duration samplePeriod = 0.1
-    "The sample period of the noise buffer";
 protected
     Real coefficient "The intermediate container for the kernel evaluations";
   algorithm
@@ -68,7 +66,8 @@ protected
     for i in -nPast:nFuture loop
 
       // We use the kernel in -i direction to enable step response kernels
-      coefficient        :=     kernel(t=(mod(    offset,1)-i)*samplePeriod);
+      coefficient        := - kernel(t=(mod(    offset,1)-i-1)*samplePeriod)
+                            + kernel(t=(mod(    offset,1)-i+0)*samplePeriod);
 
       // We use the kernel in +i direction for the random samples
       // The +1 accounts for one-based indizes

--- a/Noise 1.0-Alpha.1/Interpolators/Utilities/Interfaces/PartialInterpolatorWithKernel/package.mo
+++ b/Noise 1.0-Alpha.1/Interpolators/Utilities/Interfaces/PartialInterpolatorWithKernel/package.mo
@@ -5,6 +5,8 @@ partial package PartialInterpolatorWithKernel "Generic interpolator interface pr
 
   redeclare replaceable function extends interpolate
   "Interpolates the buffer using a replaceable kernel"
+    input Modelica.SIunits.Duration samplePeriod = 0.1
+    "The sample period of the noise buffer";
 protected
     Real coefficient "The intermediate container for the kernel evaluations";
   algorithm
@@ -66,7 +68,7 @@ protected
     for i in -nPast:nFuture loop
 
       // We use the kernel in -i direction to enable step response kernels
-      coefficient        :=     kernel(t=mod(    offset,1)-i);
+      coefficient        :=     kernel(t=(mod(    offset,1)-i)*samplePeriod);
 
       // We use the kernel in +i direction for the random samples
       // The +1 accounts for one-based indizes


### PR DESCRIPTION
This fixes the convolution method used in the supplementary Noise library. It allows to use the actual step response of a filter to shape the output of the Noise blocks.

It affects the Modelica_Noise library only in a minor point: The Interfaces for the interpolators now also include the samplePeriod. It is not used in this library and only introduced to provide extendability via the supplementary Noise library.

This PR also fixes a small bug in the Interpolations example, where the new deafult of constant interpolation was not respected.