### PR TITLE
Fix MSVC compiler warning

### DIFF
--- a/Modelica_Noise 1.0 Beta.1/Resources/Include/ModelicaRandom.c
+++ b/Modelica_Noise 1.0 Beta.1/Resources/Include/ModelicaRandom.c
@@ -116,7 +116,7 @@
 
 
 /* USEFUL INCLUDES */
-
+#include <stdlib.h>
 /* Include some math headers */
 #include <limits.h>
 #include <math.h>


### PR DESCRIPTION
```
warning C4013: 'atexit' undefined; assuming extern returning int
```